### PR TITLE
Fix ImGui 1.92 compatibility warnings in CinderImGui

### DIFF
--- a/include/cinder/CinderImGui.h
+++ b/include/cinder/CinderImGui.h
@@ -105,17 +105,17 @@ namespace ImGui {
 	//! used here for initialization, or in App::update() only if the this window is still open.
 	CI_API bool Initialize( const Options& options = Options() );
 
-	CI_API bool DragFloat2( const char* label, glm::vec2* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", float power = 1.0f );
-	CI_API bool DragFloat3( const char* label, glm::vec3* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", float power = 1.0f );
-	CI_API bool DragFloat4( const char* label, glm::vec4* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", float power = 1.0f );
+	CI_API bool DragFloat2( const char* label, glm::vec2* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
+	CI_API bool DragFloat3( const char* label, glm::vec3* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
+	CI_API bool DragFloat4( const char* label, glm::vec4* v2, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
 
 	CI_API bool DragInt2( const char* label, glm::ivec2* v2, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%.3f" );
 	CI_API bool DragInt3( const char* label, glm::ivec3* v2, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%.3f" );
 	CI_API bool DragInt4( const char* label, glm::ivec4* v2, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%.3f" );
 
-	CI_API bool SliderFloat2( const char* label, glm::vec2* v2, float v_min, float v_max, const char* format = "%.3f", float power = 1.0f );
-	CI_API bool SliderFloat3( const char* label, glm::vec3* v2, float v_min, float v_max, const char* format = "%.3f", float power = 1.0f );
-	CI_API bool SliderFloat4( const char* label, glm::vec4* v2, float v_min, float v_max, const char* format = "%.3f", float power = 1.0f );
+	CI_API bool SliderFloat2( const char* label, glm::vec2* v2, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
+	CI_API bool SliderFloat3( const char* label, glm::vec3* v2, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
+	CI_API bool SliderFloat4( const char* label, glm::vec4* v2, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0 );
 
 	CI_API bool SliderInt2( const char* label, glm::ivec2* v2, int v_min, int v_max, const char* format = "%.3f" );
 	CI_API bool SliderInt3( const char* label, glm::ivec3* v2, int v_min, int v_max, const char* format = "%.3f" );

--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -234,19 +234,19 @@ ScopedTreeNode::~ScopedTreeNode()
 		ImGui::TreePop();
 }
 
-bool DragFloat2( const char* label, glm::vec2* v2, float v_speed, float v_min, float v_max, const char* format, float power )
+bool DragFloat2( const char* label, glm::vec2* v2, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return DragFloat2( label, glm::value_ptr( *v2 ), v_speed, v_min, v_max, format, power );
+	return DragFloat2( label, glm::value_ptr( *v2 ), v_speed, v_min, v_max, format, flags );
 }
 
-bool DragFloat3( const char* label, glm::vec3* v3, float v_speed, float v_min, float v_max, const char* format, float power )
+bool DragFloat3( const char* label, glm::vec3* v3, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return DragFloat3( label, glm::value_ptr( *v3 ), v_speed, v_min, v_max, format, power );
+	return DragFloat3( label, glm::value_ptr( *v3 ), v_speed, v_min, v_max, format, flags );
 }
 
-bool DragFloat4( const char* label, glm::vec4* v4, float v_speed, float v_min, float v_max, const char* format, float power )
+bool DragFloat4( const char* label, glm::vec4* v4, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return DragFloat4( label, glm::value_ptr( *v4 ), v_speed, v_min, v_max, format, power );
+	return DragFloat4( label, glm::value_ptr( *v4 ), v_speed, v_min, v_max, format, flags );
 }
 
 bool DragInt2( const char* label, glm::ivec2* v2, float v_speed, int v_min, int v_max, const char* format )
@@ -264,19 +264,19 @@ bool DragInt4( const char* label, glm::ivec4* v4, float v_speed, int v_min, int 
 	return DragInt4( label, glm::value_ptr( *v4 ), v_speed, v_min, v_max, format );
 }
 
-bool SliderFloat2( const char* label, glm::vec2* v2, float v_min, float v_max, const char* format, float power )
+bool SliderFloat2( const char* label, glm::vec2* v2, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return SliderFloat2( label, glm::value_ptr( *v2 ), v_min, v_max, format, power );
+	return SliderFloat2( label, glm::value_ptr( *v2 ), v_min, v_max, format, flags );
 }
 
-bool SliderFloat3( const char* label, glm::vec3* v3, float v_min, float v_max, const char* format, float power )
+bool SliderFloat3( const char* label, glm::vec3* v3, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return SliderFloat3( label, glm::value_ptr( *v3 ), v_min, v_max, format, power );
+	return SliderFloat3( label, glm::value_ptr( *v3 ), v_min, v_max, format, flags );
 }
 
-bool SliderFloat4( const char* label, glm::vec4* v4, float v_min, float v_max, const char* format, float power )
+bool SliderFloat4( const char* label, glm::vec4* v4, float v_min, float v_max, const char* format, ImGuiSliderFlags flags )
 {
-	return SliderFloat4( label, glm::value_ptr( *v4 ), v_min, v_max, format, power );
+	return SliderFloat4( label, glm::value_ptr( *v4 ), v_min, v_max, format, flags );
 }
 
 bool SliderInt2( const char* label, glm::ivec2* v2, int v_min, int v_max, const char* format )


### PR DESCRIPTION
Fixes C4244 conversion warnings when building with ImGui 1.92.3.

The `power` parameter was removed from DragFloat/SliderFloat functions in ImGui 1.78 
and replaced with `ImGuiSliderFlags` (see ocornut/imgui#3361).

Updated CinderImGui wrapper functions to use the new API:
- DragFloat2/3/4: changed `float power = 1.0f` → `ImGuiSliderFlags flags = 0`
- SliderFloat2/3/4: changed `float power = 1.0f` → `ImGuiSliderFlags flags = 0`

Users needing non-linear behavior can now pass `ImGuiSliderFlags_Logarithmic` instead.