### PR TITLE
Cmake std fix

### DIFF
--- a/include/asio/awaitable.hpp
+++ b/include/asio/awaitable.hpp
@@ -25,6 +25,7 @@
 # include <experimental/coroutine>
 #endif // defined(ASIO_HAS_STD_COROUTINE)
 
+#include <utility>  // for std::exchange (needed in C++20)
 #include "asio/any_io_executor.hpp"
 
 #include "asio/detail/push_options.hpp"

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -79,11 +79,33 @@ if( CINDER_MSW AND MSVC )
     endif()
 endif()
 
-target_compile_features( cinder PUBLIC cxx_std_17 )
+# Determine C++ standard for Cinder (default 17, allow user override)
+if( CMAKE_CXX_STANDARD )
+    set( CINDER_CXX_STANDARD ${CMAKE_CXX_STANDARD} )
+else()
+    set( CINDER_CXX_STANDARD 17 )
+endif()
+
+# Validate minimum
+if( CINDER_CXX_STANDARD LESS 17 )
+    message( FATAL_ERROR "Cinder requires C++17 or later. CMAKE_CXX_STANDARD is set to ${CINDER_CXX_STANDARD}" )
+endif()
+
+# Set C++ standard for cinder target
+target_compile_features( cinder PUBLIC cxx_std_${CINDER_CXX_STANDARD} )
+
+# Determine CXX_EXTENSIONS: default OFF (prevents "namespace linux" issue)
+# Only enable if user explicitly sets CMAKE_CXX_EXTENSIONS=ON
+if( DEFINED CMAKE_CXX_EXTENSIONS )
+    set( CINDER_CXX_EXTENSIONS ${CMAKE_CXX_EXTENSIONS} )
+else()
+    set( CINDER_CXX_EXTENSIONS OFF )
+endif()
+
 set_target_properties( cinder PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD ${CINDER_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
+    CXX_EXTENSIONS ${CINDER_CXX_EXTENSIONS}
 )
 
 # This file will contain all dependencies, includes, definition, compiler flags and so on..
@@ -91,8 +113,9 @@ export( TARGETS cinder FILE ${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinder
 
 # And this command will generate a file on the ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
 # that applications have to pull in order to link successfully with Cinder and its dependencies.
-# This specific cinderConfig.cmake file will just hold a path to the above mention 
+# This specific cinderConfig.cmake file will just hold a path to the above mention
 # cinderTargets.cmake file which holds the actual info.
+# CINDER_CXX_STANDARD and CINDER_CXX_EXTENSIONS will be substituted into the template
 configure_file( ${CMAKE_CURRENT_LIST_DIR}/modules/cinderConfig.buildtree.cmake.in
     "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/cinderConfig.cmake"
 )

--- a/proj/cmake/modules/cinderConfig.buildtree.cmake.in
+++ b/proj/cmake/modules/cinderConfig.buildtree.cmake.in
@@ -1,5 +1,10 @@
 if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
     include( "${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake" )
+
+    # Record the C++ standard and extensions setting Cinder was built with
+    # These will be inherited by apps unless they explicitly override
+    set( CINDER_CXX_STANDARD @CINDER_CXX_STANDARD@ )
+    set( CINDER_CXX_EXTENSIONS @CINDER_CXX_EXTENSIONS@ )
 endif()
 
 

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -129,6 +129,36 @@ function( ci_make_app )
 	target_include_directories( ${ARG_APP_NAME} PUBLIC ${ARG_INCLUDES} )
 	target_link_libraries( ${ARG_APP_NAME} PUBLIC cinder ${ARG_LIBRARIES} )
 
+	# Determine C++ standard: user override > Cinder's standard > 17
+	if( CMAKE_CXX_STANDARD )
+		set( APP_CXX_STANDARD ${CMAKE_CXX_STANDARD} )
+	elseif( DEFINED CINDER_CXX_STANDARD )
+		set( APP_CXX_STANDARD ${CINDER_CXX_STANDARD} )
+	else()
+		set( APP_CXX_STANDARD 17 )
+	endif()
+
+	if( APP_CXX_STANDARD LESS 17 )
+		message( FATAL_ERROR "Cinder requires C++17 or later. App is configured to use C++${APP_CXX_STANDARD}" )
+	endif()
+
+	target_compile_features( ${ARG_APP_NAME} PUBLIC cxx_std_${APP_CXX_STANDARD} )
+
+	# Determine CXX_EXTENSIONS: inherit from Cinder, or default OFF (prevents "namespace linux" issue)
+	if( DEFINED CMAKE_CXX_EXTENSIONS )
+		set( APP_CXX_EXTENSIONS ${CMAKE_CXX_EXTENSIONS} )
+	elseif( DEFINED CINDER_CXX_EXTENSIONS )
+		set( APP_CXX_EXTENSIONS ${CINDER_CXX_EXTENSIONS} )
+	else()
+		set( APP_CXX_EXTENSIONS OFF )
+	endif()
+
+	set_target_properties( ${ARG_APP_NAME} PROPERTIES
+		CXX_STANDARD ${APP_CXX_STANDARD}
+		CXX_STANDARD_REQUIRED ON
+		CXX_EXTENSIONS ${APP_CXX_EXTENSIONS}
+	)
+
 	if( MSVC )
 		# Ignore Specific Default Libraries for Debug build
 		set_target_properties( ${ARG_APP_NAME} PROPERTIES LINK_FLAGS_DEBUG "/NODEFAULTLIB:LIBCMT /NODEFAULTLIB:LIBCPMT" )


### PR DESCRIPTION
I investigated this more and discovered that CMake's `export()` command doesn't propagate `INTERFACE_CXX_STANDARD` or related properties to consuming applications. The solution appears to be capturing Cinder's C++ standard and extensions settings in `cinderConfig.cmake` and explicitly applying them to all applications via `ci_make_app()`. You'll note that the implementation uses a priority chain: user's explicit `CMAKE_CXX_STANDARD` override > Cinder's standard > default C++17. Extensions default to OFF (preventing the "namespace linux" issue) unless explicitly enabled with `CMAKE_CXX_EXTENSIONS=ON`.

Part of what this PR changes is that overriding the C++ standard - including specifying `gnu++`, should work now, and Cinder can actually build despite the `linux` definition with an additional flag.

These are the combinations I tested:

| Test Scenario | Compiler | Cinder Build Command | App Build Command | Result |
|---------------|----------|---------------------|-------------------|--------|
| Default | g++, clang++ | `cmake ..` | `cmake ..` | Both use `-std=c++17` |
| Cinder C++20, App inherits | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=20` | `cmake ..` | Both use `-std=c++20` |
| Cinder C++23, App inherits | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=23` | `cmake ..` | Both use `-std=c++23` |
| Cinder default, App C++20 | g++, clang++ | `cmake ..` | `cmake .. -DCMAKE_CXX_STANDARD=20` | Cinder `-std=c++17`, App `-std=c++20` |
| Cinder C++20, App C++23 | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=20` | `cmake .. -DCMAKE_CXX_STANDARD=23` | Cinder `-std=c++20`, App `-std=c++23` |
| Cinder gnu++17, App inherits | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=ON -DCMAKE_CXX_FLAGS="-Ulinux"` | `cmake .. -DCMAKE_CXX_FLAGS="-Ulinux"` | Both use `-std=gnu++17` with `-Ulinux` |
| Cinder gnu++20, App inherits | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=ON -DCMAKE_CXX_FLAGS="-Ulinux"` | `cmake .. -DCMAKE_CXX_FLAGS="-Ulinux"` | Both use `-std=gnu++20` with `-Ulinux` |
| Cinder default, App gnu++17 | g++, clang++ | `cmake ..` | `cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=ON -DCMAKE_CXX_FLAGS="-Ulinux"` | Cinder `-std=c++17`, App `-std=gnu++17` with `-Ulinux` |
| Cinder gnu++17, App c++20 | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=ON -DCMAKE_CXX_FLAGS="-Ulinux"` | `cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF` | Cinder `-std=gnu++17` with `-Ulinux`, App `-std=c++20` |
| Cinder c++17, App gnu++20 | g++, clang++ | `cmake ..` | `cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=ON -DCMAKE_CXX_FLAGS="-Ulinux"` | Cinder `-std=c++17`, App `-std=gnu++20` with `-Ulinux` |
| Reject C++14 | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=14` | N/A | ❌ Correctly rejected |
| Reject C++11 | g++, clang++ | `cmake .. -DCMAKE_CXX_STANDARD=11` | N/A | ❌ Correctly rejected |

- `proj/cmake/libcinder_target.cmake` - Capture C++ standard and extensions
- `proj/cmake/modules/cinderConfig.buildtree.cmake.in` - Export settings to apps
- `proj/cmake/modules/cinderMakeApp.cmake` - Apply settings to all apps
